### PR TITLE
Escaped path to checkstyle jar and checkstyle rules.

### DIFF
--- a/javalib/style61b.py
+++ b/javalib/style61b.py
@@ -50,6 +50,6 @@ else:
 
 files_to_check = set(sys.argv[1:]).difference(skipfiles)
 
-system_command = 'java -jar ' + checkstyle_jar_path +  ' -c ' + checkstyle_rules_path + " " + " ".join(files_to_check)
+system_command = 'java -jar ' + '"' + checkstyle_jar_path + '"' +  ' -c ' + '"' + checkstyle_rules_path + '"' + " " + " ".join(files_to_check)
 print("Running command: " + system_command)
 os.system(system_command)


### PR DESCRIPTION
The java call to checkstyle fails if there are spaces in the
absolute path to the jar.

<img width="850" alt="screen shot 2016-02-05 at 11 57 26 am" src="https://cloud.githubusercontent.com/assets/1368497/12857556/b72d2a2a-cbff-11e5-8cb0-c1ef94e52405.png">
